### PR TITLE
Transformar fechas del selector a su nombre del mes

### DIFF
--- a/main.py
+++ b/main.py
@@ -53,7 +53,7 @@ with st.sidebar:
             data.set_index("fecha", inplace=True)
             
             month_start_dates = data.index.to_period("M").to_timestamp().drop_duplicates().sort_values()
-            selected_month_start = st.selectbox("Selecciona el mes", month_start_dates.strftime('%Y-%m'), index=0)
+            selected_month_start = st.selectbox("Selecciona el mes", month_start_dates, index=0, format_func=lambda date: date.strftime('%B %Y'))
             selected_month_start = pd.Timestamp(selected_month_start)
             filtered_data_by_month = data[data.index.to_period("M").start_time == selected_month_start]
             


### PR DESCRIPTION
Pequeño cambio que cambie los números del mes a su nombre para que sea más sencilla su lectura.

<img width="314" alt="image" src="https://github.com/user-attachments/assets/6f9120ae-beac-4f28-a0f7-917cf8b309f6">

Espero que guste el cambio 😄